### PR TITLE
Rename the nuke variables to be less confusing

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -437,8 +437,8 @@
 			text += "<br><a href='?src=\ref[src];nuclear=lair'>To shuttle</a>, <a href='?src=\ref[src];common=undress'>undress</a>, <a href='?src=\ref[src];nuclear=dressup'>dress up</a>."
 			var/code
 			for (var/obj/machinery/nuclearbomb/bombue in world)
-				if (length(bombue.r_code) <= 5 && bombue.r_code != "LOLNO" && bombue.r_code != "ADMIN")
-					code = bombue.r_code
+				if (length(bombue.unlock_code) <= 5 && bombue.unlock_code != "LOLNO" && bombue.unlock_code != "ADMIN")
+					code = bombue.unlock_code
 					break
 			if (code)
 				text += " Code is [code]. <a href='?src=\ref[src];nuclear=tellcode'>tell the code.</a>"
@@ -1032,8 +1032,8 @@
 			if("tellcode")
 				var/code
 				for (var/obj/machinery/nuclearbomb/bombue in world)
-					if (length(bombue.r_code) <= 5 && bombue.r_code != "LOLNO" && bombue.r_code != "ADMIN")
-						code = bombue.r_code
+					if (length(bombue.unlock_code) <= 5 && bombue.unlock_code != "LOLNO" && bombue.unlock_code != "ADMIN")
+						code = bombue.unlock_code
 						break
 				if (code)
 					store_memory("<B>Syndicate Nuclear Bomb Code</B>: [code]", 0, 0)

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -21,9 +21,9 @@
 		if(2)
 			var/nukecode = rand(10000, 99999)
 			for(var/obj/machinery/nuclearbomb/bomb in world)
-				if(bomb && bomb.r_code)
+				if(bomb && bomb.unlock_code)
 					if(bomb.z == ZLEVEL_STATION)
-						bomb.r_code = nukecode
+						bomb.unlock_code = nukecode
 
 			intercepttext += "<FONT size = 3><B>NanoTrasen Update</B>: Biohazard Alert.</FONT><HR>"
 			intercepttext += "Directive 7-12 has been issued for [station_name()].<BR>"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -104,7 +104,7 @@
 		new /obj/structure/closet/syndicate/nuclear(uplinklocker.loc)
 	if(nuke_spawn && synd_spawn.len > 0)
 		var/obj/machinery/nuclearbomb/the_bomb = new /obj/machinery/nuclearbomb(nuke_spawn.loc)
-		the_bomb.r_code = nuke_code
+		the_bomb.unlock_code = nuke_code
 
 	return ..()
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -9,9 +9,9 @@ var/bomb_set
 
 	var/timeleft = 60.0
 	var/timing = 0.0
-	var/r_code = "ADMIN"
-	var/code = ""
-	var/yes_code = 0.0
+	var/unlock_code = "ADMIN"
+	var/input_code = ""
+	var/unlocked = 0
 	var/safety = 1.0
 	var/obj/item/weapon/disk/nuclear/auth = null
 	use_power = 0
@@ -28,51 +28,51 @@ var/bomb_set
 	layer = 4
 
 /obj/machinery/nuclearbomb/process()
-	if (src.timing)
+	if (timing)
 		bomb_set = 1 //So long as there is one nuke timing, it means one nuke is armed.
-		src.timeleft--
-		if (src.timeleft <= 0)
+		timeleft--
+		if (timeleft <= 0)
 			explode()
 		else
 			var/volume = (timeleft <= 20 ? 30 : 5)
 			playsound(loc, 'sound/items/timer.ogg', volume, 0)
 		for(var/mob/M in viewers(1, src))
 			if ((M.client && M.machine == src))
-				src.attack_hand(M)
+				attack_hand(M)
 	return
 
 /obj/machinery/nuclearbomb/attackby(obj/item/weapon/I as obj, mob/user as mob, params)
 	if (istype(I, /obj/item/weapon/disk/nuclear))
 		usr.drop_item()
 		I.loc = src
-		src.auth = I
-		src.add_fingerprint(user)
+		auth = I
+		add_fingerprint(user)
 		return
 	..()
 
 /obj/machinery/nuclearbomb/attack_paw(mob/user as mob)
-	return src.attack_hand(user)
+	return attack_hand(user)
 
 /obj/machinery/nuclearbomb/attack_ai(mob/user as mob)
 	return
 
 /obj/machinery/nuclearbomb/attack_hand(mob/user as mob)
 	user.set_machine(src)
-	var/dat = text("<TT>\nAuth. Disk: <A href='?src=\ref[];auth=1'>[]</A><HR>", src, (src.auth ? "++++++++++" : "----------"))
-	if (src.auth)
-		if (src.yes_code)
-			dat += text("\n<B>Status</B>: []-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] <A href='?src=\ref[];timer=1'>Toggle</A><BR>\nTime: <A href='?src=\ref[];time=-10'>-</A> <A href='?src=\ref[];time=-1'>-</A> [] <A href='?src=\ref[];time=1'>+</A> <A href='?src=\ref[];time=10'>+</A><BR>\n<BR>\nSafety: [] <A href='?src=\ref[];safety=1'>Toggle</A><BR>\nAnchor: [] <A href='?src=\ref[];anchor=1'>Toggle</A><BR>\n", (src.timing ? "Func/Set" : "Functional"), (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src, src, src, src.timeleft, src, src, (src.safety ? "On" : "Off"), src, (src.anchored ? "Engaged" : "Off"), src)
+	var/dat = text("<TT>\nAuth. Disk: <A href='?src=\ref[];auth=1'>[]</A><HR>", src, (auth ? "++++++++++" : "----------"))
+	if (auth)
+		if (unlocked)
+			dat += text("\n<B>Status</B>: []-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] <A href='?src=\ref[];timer=1'>Toggle</A><BR>\nTime: <A href='?src=\ref[];time=-10'>-</A> <A href='?src=\ref[];time=-1'>-</A> [] <A href='?src=\ref[];time=1'>+</A> <A href='?src=\ref[];time=10'>+</A><BR>\n<BR>\nSafety: [] <A href='?src=\ref[];safety=1'>Toggle</A><BR>\nAnchor: [] <A href='?src=\ref[];anchor=1'>Toggle</A><BR>\n", (timing ? "Func/Set" : "Functional"), (safety ? "Safe" : "Engaged"), timeleft, (timing ? "On" : "Off"), src, src, src, timeleft, src, src, (safety ? "On" : "Off"), src, (anchored ? "Engaged" : "Off"), src)
 		else
-			dat += text("\n<B>Status</B>: Auth. S2-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\n[] Safety: Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
+			dat += text("\n<B>Status</B>: Auth. S2-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\n[] Safety: Toggle<BR>\nAnchor: [] Toggle<BR>\n", (safety ? "Safe" : "Engaged"), timeleft, (timing ? "On" : "Off"), timeleft, (safety ? "On" : "Off"), (anchored ? "Engaged" : "Off"))
 	else
-		if (src.timing)
-			dat += text("\n<B>Status</B>: Set-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
+		if (timing)
+			dat += text("\n<B>Status</B>: Set-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (safety ? "Safe" : "Engaged"), timeleft, (timing ? "On" : "Off"), timeleft, (safety ? "On" : "Off"), (anchored ? "Engaged" : "Off"))
 		else
-			dat += text("\n<B>Status</B>: Auth. S1-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (src.safety ? "Safe" : "Engaged"), src.timeleft, (src.timing ? "On" : "Off"), src.timeleft, (src.safety ? "On" : "Off"), (src.anchored ? "Engaged" : "Off"))
+			dat += text("\n<B>Status</B>: Auth. S1-[]<BR>\n<B>Timer</B>: []<BR>\n<BR>\nTimer: [] Toggle<BR>\nTime: - - [] + +<BR>\n<BR>\nSafety: [] Toggle<BR>\nAnchor: [] Toggle<BR>\n", (safety ? "Safe" : "Engaged"), timeleft, (timing ? "On" : "Off"), timeleft, (safety ? "On" : "Off"), (anchored ? "Engaged" : "Off"))
 	var/message = "AUTH"
-	if (src.auth)
-		message = text("[]", src.code)
-		if (src.yes_code)
+	if (auth)
+		message = text("[]", input_code)
+		if (unlocked)
 			message = "*****"
 	dat += text("<HR>\n>[]<BR>\n<A href='?src=\ref[];type=1'>1</A><A href='?src=\ref[];type=2'>2</A><A href='?src=\ref[];type=3'>3</A><BR>\n<A href='?src=\ref[];type=4'>4</A><A href='?src=\ref[];type=5'>5</A><A href='?src=\ref[];type=6'>6</A><BR>\n<A href='?src=\ref[];type=7'>7</A><A href='?src=\ref[];type=8'>8</A><A href='?src=\ref[];type=9'>9</A><BR>\n<A href='?src=\ref[];type=R'>R</A><A href='?src=\ref[];type=0'>0</A><A href='?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
 	var/datum/browser/popup = new(user, "nuclearbomb", name, 300, 400)
@@ -85,28 +85,28 @@ var/bomb_set
 		return
 	usr.set_machine(src)
 	if (href_list["auth"])
-		if (src.auth)
-			src.auth.loc = src.loc
-			src.yes_code = 0
-			src.auth = null
+		if (auth)
+			auth.loc = loc
+			unlocked = 0
+			auth = null
 		else
 			var/obj/item/I = usr.get_active_hand()
 			if (istype(I, /obj/item/weapon/disk/nuclear))
 				usr.drop_item()
 				I.loc = src
-				src.auth = I
-	if (src.auth)
+				auth = I
+	if (auth)
 		if (href_list["type"])
 			if (href_list["type"] == "E")
-				if (src.code == src.r_code)
-					src.yes_code = 1
-					src.code = null
+				if (input_code == unlock_code)
+					unlocked = 1
+					input_code = null
 				else
-					src.code = "ERROR"
+					input_code = "ERROR"
 			else
 				if (href_list["type"] == "R")
-					src.yes_code = 0
-					src.code = null
+					unlocked = 0
+					input_code = null
 				else
 					lastentered = text("[]", href_list["type"])
 					if (text2num(lastentered) == null)
@@ -114,24 +114,24 @@ var/bomb_set
 						message_admins("[key_name_admin(usr)] (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) tried to exploit a nuclear bomb by entering non-numerical codes: <a href='?_src_=vars;Vars=\ref[src]'>[lastentered]</a> ! ([LOC ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[LOC.x];Y=[LOC.y];Z=[LOC.z]'>JMP</a>" : "null"])", 0)
 						log_admin("EXPLOIT : [key_name(usr)] tried to exploit a nuclear bomb by entering non-numerical codes: [lastentered] !")
 					else
-						src.code += lastentered
-						if (length(src.code) > 5)
-							src.code = "ERROR"
-		if (src.yes_code)
+						input_code += lastentered
+						if (length(input_code) > 5)
+							input_code = "ERROR"
+		if (unlocked)
 			if (href_list["time"])
 				var/time = text2num(href_list["time"])
-				src.timeleft += time
-				src.timeleft = min(max(round(src.timeleft), 60), 600)
+				timeleft += time
+				timeleft = min(max(round(timeleft), 60), 600)
 			if (href_list["timer"])
-				if (src.timing == -1.0)
+				if (timing == -1.0)
 					return
-				if (src.safety)
+				if (safety)
 					usr << "<span class='danger'>The safety is still on.</span>"
 					return
-				src.timing = !( src.timing )
-				if (src.timing)
-					src.icon_state = "nuclearbomb2"
-					if(!src.safety)
+				timing = !( timing )
+				if (timing)
+					icon_state = "nuclearbomb2"
+					if(!safety)
 						bomb_set = 1//There can still be issues with this reseting when there are multiple bombs. Not a big deal tho for Nuke/N
 						var/current_level = get_security_level()
 						previous_level = "[current_level == "delta" ? "red" : current_level ]" //If a nuke is armed during Delta, it will stand down to Red Alert when disarmed.
@@ -140,34 +140,34 @@ var/bomb_set
 						bomb_set = 0
 						set_security_level("[previous_level]")
 				else
-					src.icon_state = "nuclearbomb1"
+					icon_state = "nuclearbomb1"
 					bomb_set = 0
 					set_security_level("[previous_level]")
 			if (href_list["safety"])
-				src.safety = !( src.safety )
-				src.icon_state = "nuclearbomb1"
+				safety = !( safety )
+				icon_state = "nuclearbomb1"
 				if(safety)
-					src.timing = 0
+					timing = 0
 					bomb_set = 0
 					set_security_level("[previous_level]")
 			if (href_list["anchor"])
 				if(!isinspace()&&(!immobile))
-					src.anchored = !( src.anchored )
+					anchored = !( anchored )
 				else if(immobile)
 					usr << "<span class='warning'>This device is immovable!</span>"
 				else
 					usr << "<span class='warning'>There is nothing to anchor to!</span>"
-	src.add_fingerprint(usr)
+	add_fingerprint(usr)
 	for(var/mob/M in viewers(1, src))
 		if ((M.client && M.machine == src))
-			src.attack_hand(M)
+			attack_hand(M)
 
 
 /obj/machinery/nuclearbomb/ex_act(severity, target)
 	return
 
 /obj/machinery/nuclearbomb/blob_act()
-	if (src.timing == -1.0)
+	if (timing == -1.0)
 		return
 	else
 		return ..()
@@ -176,13 +176,13 @@ var/bomb_set
 
 #define NUKERANGE 80
 /obj/machinery/nuclearbomb/proc/explode()
-	if (src.safety)
-		src.timing = 0
+	if (safety)
+		timing = 0
 		return
-	src.timing = -1.0
-	src.yes_code = 0
-	src.safety = 1
-	src.icon_state = "nuclearbomb3"
+	timing = -1.0
+	unlocked = 0
+	safety = 1
+	icon_state = "nuclearbomb3"
 	for(var/mob/M in player_list)
 		M << 'sound/machines/Alarm.ogg'
 	if (ticker && ticker.mode)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -264,7 +264,7 @@ client/proc/one_click_antag()
 
 		if(nuke_spawn)
 			var/obj/machinery/nuclearbomb/the_bomb = new /obj/machinery/nuclearbomb(nuke_spawn.loc)
-			the_bomb.r_code = nuke_code
+			the_bomb.unlock_code = nuke_code
 
 		if(closet_spawn)
 			new /obj/structure/closet/syndicate/nuclear(closet_spawn.loc)


### PR DESCRIPTION
Who even names three variables with distinct uses non-indicative variants of code?

protip: unlock code is the code you need to input to unlock the nuke

also removes unnecessary `src.` from the nuke file