### PR TITLE
Fix landmarks being modified by explosions and related stuff

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -86,6 +86,26 @@
 	landmarks_list -= src
 	..()
 
+//this is really dumb
+/obj/effect/landmark/SinguloCanEat()
+	return 0
+
+/obj/effect/landmark/singularity_act()
+	return 0
+
+/obj/effect/landmark/narsie_act()
+	return 0
+
+/obj/effect/landmark/acid_act()
+	return 0
+
+/obj/effect/landmark/singularity_pull()
+	return 0
+
+/obj/effect/landmark/ex_act()
+	return 0
+
+
 /obj/effect/landmark/start
 	name = "start"
 	icon = 'icons/mob/screen_gen.dmi'


### PR DESCRIPTION
Landmarks getting deleted when they're not supposed to is capable of really breaking stuff