### PR TITLE
Change eye setting logic in adv camera console

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -56,6 +56,7 @@
 			eyeobj.initialized = 1
 		else
 			eyeobj.setLoc(eyeobj.loc)
+		L.client.eye = eyeobj
 	else
 		user << "The console is already in use!"
 
@@ -87,7 +88,6 @@
 				user.client.images -= user_image
 				user_image = image(icon,loc,icon_state,FLY_LAYER)
 				user.client.images += user_image
-			user.client.eye = src
 
 /mob/camera/aiEye/remote/relaymove(mob/user,direct)
 	var/initial = initial(sprint)


### PR DESCRIPTION
The eye getting set on every move might be the actual reason behind the camera wigging out