### PR TITLE
Make items that stop bleeding not care if the limb is missing

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -63,18 +63,19 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/organ/O = H.get_organdatum(check_zone(user.zone_sel.selecting))
 		var/obj/item/organ/limb/affecting = O.organitem
-		if(!affecting)
-			return //no limb to heal
 		if(stop_bleeding)
 			if(!H.bleedsuppress) //so you can't stack bleed suppression
 				H.suppress_bloodloss(stop_bleeding)
-		if(affecting.status == ORGAN_ORGANIC) //Limb must be organic to be healed - RR
-			if(affecting.heal_damage(heal_brute, heal_burn, 0))
-				H.update_damage_overlays(0)
-
-			M.updatehealth()
+		if(affecting)
+			if(affecting.status == ORGAN_ORGANIC) //Limb must be organic to be healed - RR
+				if(affecting.heal_damage(heal_brute, heal_burn, 0))
+					H.update_damage_overlays(0)
+				M.updatehealth()
+			else
+				user << "<span class='notice'>Medicine won't work on a robotic limb!</span>"
 		else
-			user << "<span class='notice'>Medicine won't work on a robotic limb!</span>"
+			if(!stop_bleeding)
+				return //Use a stack if it stops the bleeding
 	else
 		M.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
 


### PR DESCRIPTION
They still stopped the bleeding when you used them in an existing limb
because the bleeding code is done on the mob, not the organsystem, so
all this does is make using bandages on destroyed/missing limbs work
without you having to target your chest or another existing limb

This technically fixes #131